### PR TITLE
Changed to not use detachFd and native close, instead close the file …

### DIFF
--- a/shared_storage/contentresolver.cpp
+++ b/shared_storage/contentresolver.cpp
@@ -16,6 +16,7 @@ class AndroidFile : public QFile {
 public:
     AndroidFile() {}
     virtual ~AndroidFile() {
+        flush();
         androidFileDescriptor_.callMethod<void>("close");
     }
 


### PR DESCRIPTION
…descriptor via jni on destruction. Needed in order to save files on Google Drive, seems like the jni close call is what triggers file upload to Google Drive. If detachFd is used, a warning like "ParcelFileDescriptor: Peer expected signal when closed; unable to deliver after detach" is produced when selecting a file from Google Drive.

